### PR TITLE
Fixed reference conditional tag to corresponding query.

### DIFF
--- a/wpcasa/includes/class-wpsight-search.php
+++ b/wpcasa/includes/class-wpsight-search.php
@@ -24,7 +24,7 @@ class WPSight_Search {
 	 *
 	 * @uses wpsight_post_type()
 	 * @uses wpsight_taxonomies()
-	 * @uses is_tax()
+	 * @uses $query->is_tax()
 	 * @uses $query->is_main_query()
 	 * @uses $query->set()
 	 *

--- a/wpcasa/includes/class-wpsight-search.php
+++ b/wpcasa/includes/class-wpsight-search.php
@@ -34,7 +34,7 @@ class WPSight_Search {
 		
 		// Stop if no listing tax or not main query
 		
-		if( ! is_tax( wpsight_taxonomies( 'names' ) ) || ! $query->is_main_query() )
+		if( ! $query->is_tax( wpsight_taxonomies( 'names' ) ) || ! $query->is_main_query() )
 			return;
 			
 		// Only allow order vars	


### PR DESCRIPTION
[Conditional tags](https://codex.wordpress.org/Conditional_Tags) are not fully set up in `pre_get_posts` which will throw a notice if not referenced.

You could also consider to prevent manipulating the query when not in admin, like the following: `if( ! is_admin() && ( ! $query->is_tax( wpsight_taxonomies( 'names' ) ) || ! $query->is_main_query() ) )`