### PR TITLE
Fixed rental period was returned as NULL.

### DIFF
--- a/wpcasa/includes/class-wpsight-listings.php
+++ b/wpcasa/includes/class-wpsight-listings.php
@@ -711,7 +711,7 @@ class WPSight_Listings {
 				// Get all periods
 				$periods = wpsight_rental_periods();			
 				// Set period label
-				$period = $$periods[ $period ];			
+				$period = $periods[ $period ];			
 			}
 		
 		} else {			


### PR DESCRIPTION
Seems like there was a mistake by defining a variable variable name which caused the method to return `NULL`.