### PR TITLE
adds listing_images meta box to properties admin screen

### DIFF
--- a/wpcasa/includes/class-wpsight-meta-boxes.php
+++ b/wpcasa/includes/class-wpsight-meta-boxes.php
@@ -305,6 +305,7 @@ class WPSight_Meta_Boxes {
 
 		$meta_boxes = array(
 			'listing_attributes'	=> self::meta_box_listing_attributes(),
+			'listing_images'		=> self::meta_box_images(),
 			'listing_price'			=> self::meta_box_listing_price(),
 			'listing_details'		=> self::meta_box_listing_details(),
 			'listing_location'		=> self::meta_box_listing_location(),


### PR DESCRIPTION
listing_images was not previously added to the meta_boxes array, however all other necessary methods for displaying the meta box and saving data were implemented.