### PR TITLE
Use CSS for colon after listing details

### DIFF
--- a/wpcasa/assets/css/wpsight-print.css
+++ b/wpcasa/assets/css/wpsight-print.css
@@ -173,6 +173,10 @@ a:visited {
     min-width: 50%;
 }
 
+.wpsight-listing-details .listing-details-label:after {
+    content: ':';
+}
+
 .wpsight-listing-details .listing-details-value {
     display: inline-block;
     word-break: break-all;

--- a/wpcasa/assets/css/wpsight.css
+++ b/wpcasa/assets/css/wpsight.css
@@ -407,6 +407,10 @@
     min-width: 50%;
 }
 
+.wpsight-listing-details .listing-details-label:after {
+    content: ':';
+}
+
 .wpsight-listing-details .listing-details-value {
     display: inline-block;
     word-break: break-all;

--- a/wpcasa/includes/class-wpsight-listings.php
+++ b/wpcasa/includes/class-wpsight-listings.php
@@ -830,7 +830,7 @@ class WPSight_Listings {
 
 					$listing_details .= '<span class="listing-' . wpsight_dashes( $detail ) . ' listing-details-detail" title="' . wpsight_get_detail( $detail, 'label' ) . '">';
 
-					$listing_details .= '<span class="listing-details-label">' . wpsight_get_detail( $detail, 'label' ) . ':</span> ';
+					$listing_details .= '<span class="listing-details-label">' . wpsight_get_detail( $detail, 'label' ) . '</span> ';
 					$listing_details .= '<span class="listing-details-value">' . wpsight_get_listing_detail( $detail, $post_id );
 
 					if ( wpsight_get_detail( $detail, 'unit' ) )


### PR DESCRIPTION
Makes it easier to remove the colon simply with a line of CSS if needed (e.g. when using icon labels such as [fa-bed](https://fontawesome.com/icons/bed?style=solid)).

This has no adverse impact on labels / translations.